### PR TITLE
Update image_set.rb

### DIFF
--- a/image_set.rb
+++ b/image_set.rb
@@ -69,7 +69,7 @@ module Jekyll
       # Start building tags
       source = "<#{@container_tag} class='#{@container_class}'>\n"
       # Glob the path and create tags for all images
-      Dir.glob(full_path).each do |image|
+      Dir.glob(full_path).uniq.each do |image|
         file = Pathname.new(image).basename
         src = File.join('/', @path, file)
         source += "<#{@wrap_tag} class='#{@wrap_class}'>\n"


### PR DESCRIPTION
When ever I used this code I ended up with a duplicate of each file. I'm assuming this comes from the files matching both JPG and jpg on line 68. The uniq addition should prevent that.

In case you wonder I'm on Windows 10 running Ruby V2.2.2p95 when this happens.
